### PR TITLE
Add YouTube Live Now text

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -260,11 +260,43 @@ const Header: FC<Props> = ({ background }) => {
             })}
           </Popover.Group>
           <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
-            {socialMedia.map(item => (
-              <Link key={item.href} href={item.href} className="mx-2">
-                <item.icon className="h-7 w-7 text-brand-red hover:text-white transition-all cursor-pointer" />
-              </Link>
-            ))}
+            {socialMedia.map(item => {
+              if (item.name === "YouTube") {
+                item.href = "/live";
+                const date = new Date();
+
+                // matches Sunday between 10:45 -> 12:30
+                const streamStart = [10, 45]
+                const streamEnd = [12, 30];
+
+                const hours = date.getHours();
+                const mins = date.getMinutes();
+
+                const isWithinTimeRange = date.getDay() === 0 &&
+                hours >= streamStart[0]
+                && mins >= streamStart[1]
+                && hours <= streamEnd[0]
+                && mins <= streamEnd[1];
+
+                if (isWithinTimeRange) {
+                  return (
+                    <>
+                      <span className="text-white">Live Now!</span>
+                      <Link key={item.href} href={item.href} className="mx-2">
+                        <item.icon className="h-7 w-7 text-brand-red hover:text-white transition-all cursor-pointer" />
+                      </Link>
+                    </>
+                  )
+                }
+              }
+
+              return (
+                <Link key={item.href} href={item.href} className="mx-2">
+                  <item.icon className="h-7 w-7 text-brand-red hover:text-white transition-all cursor-pointer" />
+                </Link>
+              )
+            }
+            )}
           </div>
         </div>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -262,7 +262,6 @@ const Header: FC<Props> = ({ background }) => {
           <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
             {socialMedia.map(item => {
               if (item.name === "YouTube") {
-                item.href = "/live";
                 const date = new Date();
 
                 // matches Sunday between 10:45 -> 12:30
@@ -279,6 +278,8 @@ const Header: FC<Props> = ({ background }) => {
                 && mins <= streamEnd[1];
 
                 if (isWithinTimeRange) {
+                  item.href = "/live";
+
                   return (
                     <>
                       <span className="text-white">Live Now!</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "freedomchurchcheltenham.com",
+  "name": "freedomcheltenham.church",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "freedomchurchcheltenham.com",
+      "name": "freedomcheltenham.church",
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
@@ -16,7 +16,7 @@
         "react-icons": "^5.3.0"
       },
       "bin": {
-        "freedomchurchcheltenham.com": "server.js"
+        "freedomcheltenham.church": "server.js"
       },
       "devDependencies": {
         "@types/node": "^18.14.0",


### PR DESCRIPTION
Adds "Live Now" text next to the YouTube button when on Sunday between typical stream times. Adjust as needed.

I did look into API requests to Google for the live status, which is possible, but requires an API key and is limited in the amount of requests we can make per day.

Alternatively we could scrape the channel page using fetch api and look for the livestream, but I think the date range is the least prone to failure, albeit not 100% accurate.